### PR TITLE
Fix ConditionalConfig

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,6 +26,7 @@ module.exports = {
     siteUrl: `https://www.evanbancroft.com`,
   },
   plugins: [
+    ...conditionalConfig,
     {
       resolve: `gatsby-plugin-alias-imports`,
       options: {


### PR DESCRIPTION
# Description

This PR actually enables the `conditionalConfig` in `gatsby-config`. This should fix the issue where GA is not picking up any data. 

# Considerations

- [x] App successfully builds w/ `gatsby build`

# How to test

1.
1.

## Screenshots (if applicable)
